### PR TITLE
fix(gcp): fixing failed publish job

### DIFF
--- a/.github/workflows/publish-cloud-function.yaml
+++ b/.github/workflows/publish-cloud-function.yaml
@@ -86,7 +86,7 @@ jobs:
           echo ::set-output name=stage::${STAGE}
 
       - name: Authenticate to Google Cloud
-        uses: camunda-cloud/action-google-auth@v1
+        uses: camunda-cloud/action-google-auth@v1.0.0
         with:
           account-alias: ${{ steps.secrets.outputs.GCP_PROJECT_ID }}
 


### PR DESCRIPTION
## Description

Likely fixes https://github.com/camunda/connector-sqs/actions/runs/3201725159/jobs/5229985359.

Seems like `v1` was removed and only `v1.0.0` [release left](https://github.com/camunda-cloud/action-google-auth/releases), while there are still both `v1` and `v1.0.0` tags present.
